### PR TITLE
Gaminator - It's Alive!

### DIFF
--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -152,12 +152,12 @@ class Gaminator(commands.Cog):
 
                     if reaction.emoji == LEFT_ARROW or reaction.emoji == RIGHT_ARROW:
 
-                        await reaction.remove(user)
-
                         i = -1 if reaction.emoji == LEFT_ARROW else 1
                         current_page_num = (current_page_num + i) % num_pages
                         current_page_dict = get_current_page_dict(pages[current_page_num])
+
                         await set_page(ctx, current_page_dict, menu_embed, num_pages, current_page_num, menu_msg)
+                        await reaction.remove(user)
 
                     elif reaction.emoji == CHECK_MARK:
 
@@ -172,8 +172,6 @@ class Gaminator(commands.Cog):
 
                     elif reaction.emoji in [e for e in ri_alphabet(len(current_page_dict))]: # If reaction is a valid and applicable regional indicator
 
-                        await reaction.remove(user)
-
                         if current_page_dict[reaction.emoji]['role-name'] not in [role.name for role in user.roles]: # If user doesn't already have role
                             field_index = 0
                             update_list = update_roles_list(reaction, user, current_page_dict, roles_to_add) # field_index: 0 is 'Adding' field; 1 is 'Removing' field
@@ -185,6 +183,7 @@ class Gaminator(commands.Cog):
                         menu_embed.set_field_at(field_index, name=('Adding' if field_index == 0 else 'Removing'), value=('None' if len(update_list) == 0 else update_field))
 
                         await menu_msg.edit(embed=menu_embed)
+                        await reaction.remove(user)
 
                     else: # Disregard impertinent reactions
 

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -80,6 +80,9 @@ class Gaminator(commands.Cog):
         role_msg = await ctx.send(embed=role_embed)
         await set_page(current_page_dict, menu_msg, current_page_num, num_pages)
 
+        roles_to_add = []
+        roles_to_remove = []
+
         while True:
             payload = await self.bot.wait_for('reaction_add', timeout=60.0)
 
@@ -93,6 +96,18 @@ class Gaminator(commands.Cog):
                 await set_page(current_page_dict, menu_msg, current_page_num, num_pages)
             elif payload[0].emoji in [e for e in ri_alphabet(len(current_page_dict))]:
                 await payload[0].remove(payload[1])
+
+                if current_page_dict[payload[0].emoji]['role-name'] in [role.name for role in payload[1].roles]:
+                    if current_page_dict[payload[0].emoji] not in roles_to_remove:
+                        roles_to_remove.append(current_page_dict[payload[0].emoji])
+                    else:
+                        roles_to_remove.remove(current_page_dict[payload[0].emoji])
+                        
+                else:
+                    if current_page_dict[payload[0].emoji] not in roles_to_add:
+                        roles_to_add.append(current_page_dict[payload[0].emoji])
+                    else:
+                        roles_to_add.remove(current_page_dict[payload[0].emoji])
 
 def setup(bot):
     bot.add_cog(Gaminator(bot))

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -19,7 +19,8 @@ def role_dict_list_to_role_ping_list(role_dict_list):
     role_names = []
 
     for d in role_dict_list:
-        role_names.append('`@' + d['role-name'] + '`')
+        role_name = d['role-name']
+        role_names.append(f'`@{role_name}`')
 
     return role_names
 
@@ -42,7 +43,10 @@ async def update_roles_to_remove(reaction, user, current_page_dict, roles_to_rem
 def get_menu_field(current_page_dict):
     menu_field = ''
     for k, v in current_page_dict.items():
-        menu_field += k + ' - `@' + v['role-name'] + '` - ' + v['qualified-name'] + '\n'
+        role_name = v['role-name']
+        qualified_name = v['qualified-name']
+        padding = (10 - len(role_name)) * '\u2000' # EN QUAD space
+        menu_field += f'{k}\u2000\u2000\u2000`@{role_name}`{padding} {qualified_name}\n'
 
     return menu_field
 

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -14,6 +14,7 @@ LEFT_ARROW = '\u2b05'
 CHECK_MARK = '\u2705'
 RIGHT_ARROW = '\u27a1'
 
+# Makes a list of role pings from a list of role dicts
 def role_dict_list_to_role_ping_list(role_dict_list):
     role_names = []
 
@@ -50,16 +51,16 @@ async def set_page(ctx, current_page_dict, menu_embed, num_pages, current_page_n
     menu_embed.set_field_at(2, name=f'Page {current_page_num + 1}/{num_pages}', value=menu_field, inline=False)
     await menu_msg.edit(embed=menu_embed)
 
-    menu_msg = await ctx.fetch_message(menu_msg.id)
+    menu_msg = await ctx.fetch_message(menu_msg.id) # Update the message's reaction list
 
-    last_index = len(current_page_dict) - 1 + 3
-    current_index = len(menu_msg.reactions) - 1
-    if current_index < last_index:
+    last_index = len(current_page_dict) - 1 + 3 # Where the last regional indicator 'should' be on the message (Note: +3 is for the left arrow, check mark and right arrow)
+    current_index = len(menu_msg.reactions) - 1 # Where the last regional indicator currently is on the message
+    if current_index < last_index: # If there are fewer regional indicators than we need, add more
         current_index += 1
         while current_index <= last_index:
             await menu_msg.add_reaction(ri_at_index(current_index - 3))
             current_index += 1
-    elif current_index > last_index:
+    elif current_index > last_index: # If there are greater regional indicators than we need, remove extraneous
         while current_index > last_index:
             await menu_msg.remove_reaction(ri_at_index(current_index - 3), ctx.bot.user)
             current_index -= 1
@@ -82,6 +83,7 @@ async def init_menu(ctx, current_page_dict, menu_embed, num_pages):
 
     return menu_msg
 
+# Rebuild the page dict into an annotated form of 'formatted_roles_dict'
 def get_current_page_dict(page):
     ret = {}
     for i in range(len(page)):
@@ -89,6 +91,7 @@ def get_current_page_dict(page):
 
     return ret
 
+# Break 'd' up into a list of dictionaries with a maximum of EMBED_MAX_LINE keys
 def page_dict_as_lines(d, max_lines=EMBED_MAX_LINES):
     if max_lines > 17:
         max_lines = 17
@@ -110,6 +113,7 @@ def page_dict_as_lines(d, max_lines=EMBED_MAX_LINES):
 
     return pages
 
+# Key is raw role name, value is qualified name
 def format_roles_dict(raw):
     ret = {}
 
@@ -126,16 +130,17 @@ class Gaminator(commands.Cog):
     async def other_games(self, ctx):
         logger.info(f'{ctx.message.author} called other_games')
 
-        formatted_roles_dict = format_roles_dict(ROLES['other_games'])
-        pages = page_dict_as_lines(formatted_roles_dict)
+        formatted_roles_dict = format_roles_dict(ROLES['other_games']) # Key is raw role name, value is qualified name
+        pages = page_dict_as_lines(formatted_roles_dict) # Each key in formatted_roles_dict is one 'line'
         num_pages = len(pages)
 
         current_page_num = 0
-        current_page_dict = get_current_page_dict(pages[current_page_num]) # Gets a dict indexed by emoji
+        current_page_dict = get_current_page_dict(pages[current_page_num]) # Gets a dict of roles indexed by emoji
 
-        menu_embed = default_embed(title=f'Other Games')
+        menu_embed = default_embed(title=f'Other Games') # Dummy embed to update within functions
         menu_msg = await init_menu(ctx, current_page_dict, menu_embed, num_pages)
 
+        # Internal state keeping
         roles_to_add = []
         roles_to_remove = []
 
@@ -143,29 +148,43 @@ class Gaminator(commands.Cog):
             while True:
                 reaction, user = await self.bot.wait_for('reaction_add', timeout=60.0)
 
-                if user == ctx.message.author:
+                if user == ctx.message.author: # Respond to reactions made by the command caller
+
                     if reaction.emoji == LEFT_ARROW or reaction.emoji == RIGHT_ARROW:
+
                         await reaction.remove(user)
+
                         i = -1 if reaction.emoji == LEFT_ARROW else 1
                         current_page_num = (current_page_num + i) % num_pages
                         current_page_dict = get_current_page_dict(pages[current_page_num])
                         await set_page(ctx, current_page_dict, menu_embed, num_pages, current_page_num, menu_msg)
+
                     elif reaction.emoji == CHECK_MARK:
+
                         autorole = self.bot.get_cog('Autorole')
                         await autorole.other_game_add(ctx, *[role['qualified-name'] for role in roles_to_add])
                         await autorole.other_game_remove(ctx, *[role['qualified-name'] for role in roles_to_remove])
+
                         break
-                    elif reaction.emoji in [e for e in ri_alphabet(len(current_page_dict))]:
+
+                    elif reaction.emoji in [e for e in ri_alphabet(len(current_page_dict))]: # If reaction is a valid and applicable regional indicator
+
                         await reaction.remove(user)
-                        if current_page_dict[reaction.emoji]['role-name'] not in [role.name for role in user.roles]:
-                            update_list, field_index = await update_roles_to_add(reaction, user, current_page_dict, roles_to_add)
+
+                        if current_page_dict[reaction.emoji]['role-name'] not in [role.name for role in user.roles]: # If user doesn't already have role
+                            update_list, field_index = await update_roles_to_add(reaction, user, current_page_dict, roles_to_add) # field_index: 0 is 'Adding' field; 1 is 'Removing' field
                         else:
                             update_list, field_index = await update_roles_to_remove(reaction, user, current_page_dict, roles_to_remove)
+
                         update_field = '\n'.join(role_dict_list_to_role_ping_list(update_list))
                         menu_embed.set_field_at(field_index, name=('Adding' if field_index == 1 else 'Removing'), value=('None' if len(update_list) == 0 else update_field))
+
                         await menu_msg.edit(embed=menu_embed)
-                elif not user.bot:
+
+                elif not user.bot: # Disregard reactions made by third parties
+
                     await reaction.remove(user)
+
         except asyncio.TimeoutError:
             logger.info(f'{ctx.message.author} timed out.')
         finally:

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -1,5 +1,5 @@
 import logging
-from asyncio import TimeoutError
+import asyncio
 
 from cogs.config.roles import ROLES
 from modules.custom_embed import default_embed
@@ -49,7 +49,7 @@ async def set_page(current_page_dict, menu_msg, current_page_num, num_pages):
 def page_dict_as_lines(d, max_lines=EMBED_MAX_LINES):
     if max_lines > 17:
         max_lines = 17
-    else if max_lines < 2:
+    elif max_lines < 2:
         max_lines = 2
 
     pages = []
@@ -140,7 +140,7 @@ class Gaminator(commands.Cog):
                         await autorole.other_game_add(ctx, *[role['qualified-name'] for role in roles_to_add])
                         await autorole.other_game_remove(ctx, *[role['qualified-name'] for role in roles_to_remove])
                         break
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.info(f'{ctx.message.author} timed out.')
         finally:
             await ctx.message.delete()

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -177,7 +177,7 @@ class Gaminator(commands.Cog):
                             update_list, field_index = await update_roles_to_remove(reaction, user, current_page_dict, roles_to_remove)
 
                         update_field = '\n'.join(role_dict_list_to_role_ping_list(update_list))
-                        menu_embed.set_field_at(field_index, name=('Adding' if field_index == 1 else 'Removing'), value=('None' if len(update_list) == 0 else update_field))
+                        menu_embed.set_field_at(field_index, name=('Adding' if field_index == 0 else 'Removing'), value=('None' if len(update_list) == 0 else update_field))
 
                         await menu_msg.edit(embed=menu_embed)
 

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -127,6 +127,7 @@ class Gaminator(commands.Cog):
         self.bot = bot
 
     @commands.command(name='other-games')
+    @commands.cooldown(1, 1800, commands.BucketType.user)
     async def other_games(self, ctx):
         logger.info(f'{ctx.message.author} called other_games')
 
@@ -190,6 +191,7 @@ class Gaminator(commands.Cog):
         finally:
             await ctx.message.delete()
             await menu_msg.delete()
+            self.bot.get_command('other-games').reset_cooldown(ctx)
 
 def setup(bot):
     bot.add_cog(Gaminator(bot))

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -162,9 +162,12 @@ class Gaminator(commands.Cog):
 
                     elif reaction.emoji == CHECK_MARK:
 
-                        autorole = self.bot.get_cog('Autorole')
-                        await autorole.other_game_add(ctx, *[role['qualified-name'] for role in roles_to_add])
-                        await autorole.other_game_remove(ctx, *[role['qualified-name'] for role in roles_to_remove])
+                        if len(roles_to_add) > 0 and len(roles_to_remove) > 0:
+                            autorole = self.bot.get_cog('Autorole')
+                            if len(roles_to_add) > 0:
+                                await autorole.other_game_add(ctx, *[role['qualified-name'] for role in roles_to_add])
+                            if len(roles_to_remove) > 0:
+                                await autorole.other_game_remove(ctx, *[role['qualified-name'] for role in roles_to_remove])
 
                         break
 

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -149,9 +149,12 @@ class Gaminator(commands.Cog):
         roles_to_add = []
         roles_to_remove = []
 
+        def check_in_ctx(reaction, user):
+            return reaction.message.id == menu_msg.id
+
         try:
             while True:
-                reaction, user = await self.bot.wait_for('reaction_add', timeout=60.0)
+                reaction, user = await self.bot.wait_for('reaction_add', timeout=60.0, check=check_in_ctx)
 
                 if user == ctx.message.author: # Respond to reactions made by the command caller
 

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -162,7 +162,7 @@ class Gaminator(commands.Cog):
 
                     elif reaction.emoji == CHECK_MARK:
 
-                        if len(roles_to_add) > 0 and len(roles_to_remove) > 0:
+                        if len(roles_to_add) > 0 or len(roles_to_remove) > 0:
                             autorole = self.bot.get_cog('Autorole')
                             if len(roles_to_add) > 0:
                                 await autorole.other_game_add(ctx, *[role['qualified-name'] for role in roles_to_add])

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -47,6 +47,11 @@ async def set_page(current_page_dict, menu_msg, current_page_num, num_pages):
     await menu_msg.add_reaction('\u2705') # Check mark
 
 def page_dict_as_lines(d, max_lines=EMBED_MAX_LINES):
+    if max_lines > 17:
+        max_lines = 17
+    else if max_lines < 2:
+        max_lines = 2
+
     pages = []
     current_page = {}
     current_line = 0

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 
 logger = logging.getLogger('voluspa.cog.gaminator')
 
-EMBED_MAX_LINES = 8
+EMBED_MAX_LINES = 7
 LEFT_ARROW = '\u2b05'
 CHECK_MARK = '\u2705'
 RIGHT_ARROW = '\u27a1'

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -1,0 +1,98 @@
+import logging
+
+from cogs.config.roles import ROLES
+from modules.custom_embed import default_embed
+from modules.emoji_utils import ri_at_index, ri_alphabet
+
+from discord.ext import commands
+
+EMBED_MAX_LINES = 7
+logger = logging.getLogger('voluspa.cog.gaminator')
+
+def get_current_page_dict(page):
+    ret = {}
+    for i in range(len(page)):
+        ret[ri_at_index(i)] = {'role-name': list(page)[i], 'qualified-name': page[list(page)[i]]}
+
+    return ret
+
+async def set_page(current_page_dict, menu_msg, current_page_num, num_pages):
+    menu_description = ''
+    for k, v in current_page_dict.items():
+        menu_description += k + ' - `@' + v['role-name'] + '` - ' + v['qualified-name'] + '\n'
+
+    menu_embed = default_embed(title=f'Other Games {current_page_num + 1}/{num_pages}', description=menu_description)
+
+    await menu_msg.clear_reactions()
+    await menu_msg.edit(embed=menu_embed)
+
+    if current_page_num > 0:
+        await menu_msg.add_reaction('\u2b05') # Left arrow
+
+    for k in current_page_dict.keys():
+        await menu_msg.add_reaction(k)
+
+    if current_page_num < num_pages - 1:
+        await menu_msg.add_reaction('\u27a1') # Right arrow
+
+    await menu_msg.add_reaction('\u2705') # Check mark
+
+def page_dict_as_lines(d, max_lines=EMBED_MAX_LINES):
+    pages = []
+    current_page = {}
+    current_line = 0
+    for k, v in d.items():
+        if current_line % max_lines == 0 and current_line > 0:
+            pages.append(current_page)
+            current_page = {}
+        current_page[k] = v
+        current_line += 1
+
+    return pages
+
+def format_roles_dict(raw):
+    ret = {}
+
+    for k, v in raw.items():
+        ret[k] = v[0].title()
+
+    return ret
+
+class Gaminator(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name='other-games')
+    async def other_games(self, ctx):
+        formatted_roles_dict = format_roles_dict(ROLES['other_games'])
+        pages = page_dict_as_lines(formatted_roles_dict)
+
+        current_page_num = 0
+        num_pages = len(pages)
+        current_page_dict = get_current_page_dict(pages[current_page_num]) # Gets a dict indexed by emoji
+
+        menu_embed = default_embed(title=f'Other Games {current_page_num + 1}/{num_pages}')
+        role_embed = default_embed(title='Your Roles')
+        role_embed.add_field(name='Adding', value='None')
+        role_embed.add_field(name='Removing', value='None')
+
+        menu_msg = await ctx.send(embed=menu_embed)
+        role_msg = await ctx.send(embed=role_embed)
+        await set_page(current_page_dict, menu_msg, current_page_num, num_pages)
+
+        while True:
+            payload = await self.bot.wait_for('reaction_add', timeout=60.0)
+
+            if payload[0].emoji == '\u2b05' and current_page_num > 0:
+                current_page_num -= 1
+                current_page_dict = get_current_page_dict(pages[current_page_num])
+                await set_page(current_page_dict, menu_msg, current_page_num, num_pages)
+            elif payload[0].emoji == '\u27a1' and current_page_num < num_pages - 1:
+                current_page_num += 1
+                current_page_dict = get_current_page_dict(pages[current_page_num])
+                await set_page(current_page_dict, menu_msg, current_page_num, num_pages)
+            elif payload[0].emoji in [e for e in ri_alphabet(len(current_page_dict))]:
+                await payload[0].remove(payload[1])
+
+def setup(bot):
+    bot.add_cog(Gaminator(bot))

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -9,6 +9,14 @@ from discord.ext import commands
 EMBED_MAX_LINES = 7
 logger = logging.getLogger('voluspa.cog.gaminator')
 
+def role_dict_list_to_role_ping_list(role_dict_list):
+    role_names = []
+
+    for d in role_dict_list:
+        role_names.append('`@' + d['role-name'] + '`')
+
+    return role_names
+
 def get_current_page_dict(page):
     ret = {}
     for i in range(len(page)):
@@ -76,8 +84,8 @@ class Gaminator(commands.Cog):
         role_embed.add_field(name='Adding', value='None')
         role_embed.add_field(name='Removing', value='None')
 
-        menu_msg = await ctx.send(embed=menu_embed)
         role_msg = await ctx.send(embed=role_embed)
+        menu_msg = await ctx.send(embed=menu_embed)
         await set_page(current_page_dict, menu_msg, current_page_num, num_pages)
 
         roles_to_add = []
@@ -102,12 +110,19 @@ class Gaminator(commands.Cog):
                         roles_to_remove.append(current_page_dict[payload[0].emoji])
                     else:
                         roles_to_remove.remove(current_page_dict[payload[0].emoji])
-                        
+
+                    roles_to_remove_field = "\n".join(role_dict_list_to_role_ping_list(roles_to_remove))
+                    role_embed.set_field_at(1, name='Removing', value=('None' if len(roles_to_remove) == 0 else roles_to_remove_field))
+                    await role_msg.edit(embed=role_embed)
                 else:
                     if current_page_dict[payload[0].emoji] not in roles_to_add:
                         roles_to_add.append(current_page_dict[payload[0].emoji])
                     else:
                         roles_to_add.remove(current_page_dict[payload[0].emoji])
+
+                    roles_to_add_field = "\n".join(role_dict_list_to_role_ping_list(roles_to_add))
+                    role_embed.set_field_at(0, name='Adding', value=('None' if len(roles_to_add) == 0 else roles_to_add_field))
+                    await role_msg.edit(embed=role_embed)
 
 def setup(bot):
     bot.add_cog(Gaminator(bot))

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -24,7 +24,7 @@ def role_dict_list_to_role_ping_list(role_dict_list):
 
     return role_names
 
-async def update_roles_list(reaction, user, current_page_dict, roles_list):
+def update_roles_list(reaction, user, current_page_dict, roles_list):
     if current_page_dict[reaction.emoji] not in roles_list:
         roles_list.append(current_page_dict[reaction.emoji])
     else:
@@ -176,10 +176,10 @@ class Gaminator(commands.Cog):
 
                         if current_page_dict[reaction.emoji]['role-name'] not in [role.name for role in user.roles]: # If user doesn't already have role
                             field_index = 0
-                            update_list = await update_roles_list(reaction, user, current_page_dict, roles_to_add) # field_index: 0 is 'Adding' field; 1 is 'Removing' field
+                            update_list = update_roles_list(reaction, user, current_page_dict, roles_to_add) # field_index: 0 is 'Adding' field; 1 is 'Removing' field
                         else:
                             field_index = 1
-                            update_list = await update_roles_list(reaction, user, current_page_dict, roles_to_remove)
+                            update_list = update_roles_list(reaction, user, current_page_dict, roles_to_remove)
 
                         update_field = '\n'.join(role_dict_list_to_role_ping_list(update_list))
                         menu_embed.set_field_at(field_index, name=('Adding' if field_index == 0 else 'Removing'), value=('None' if len(update_list) == 0 else update_field))

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -1,7 +1,6 @@
 import logging
 
 from cogs.config.roles import ROLES
-<<<<<<< HEAD
 from modules.custom_embed import default_embed
 from modules.emoji_utils import ri_at_index, ri_alphabet
 
@@ -66,61 +65,6 @@ def format_roles_dict(raw):
         ret[k] = v[0].title()
 
     return ret
-=======
-from modules.misc import chunk_list
-from modules.custom_embed import default_embed
-
-from discord.ext import commands
-
-logger = logging.getLogger('voluspa.cog.gaminator')
-
-async def set_page(page, chunked_lines, result_msg):
-    description_string = ''
-    react_char = '\U0001f1e6'
-    for line in chunked_lines[page]:
-        description_string += react_char + ' - ' + line + '\n'
-        react_char = chr(ord(react_char) + 1)
-
-    result_embed = default_embed(
-        title='Other Games',
-        description=description_string
-    )
-
-    await result_msg.clear_reactions()
-    await result_msg.edit(embed=result_embed)
-
-    if page > 0:
-        await result_msg.add_reaction('\u2b05')
-
-    react_char = '\U0001f1e6'
-    for i in range(0, len(chunked_lines[page])):
-        await result_msg.add_reaction(react_char)
-        react_char = chr(ord(react_char) + 1)
-
-    if page < len(chunked_lines) - 1:
-        await result_msg.add_reaction('\u27a1')
-    await result_msg.add_reaction('\u2705')
-
-def chunk_lines(lines, max_lines=7):
-    if max_lines < 0:
-        max_lines = 0
-
-    chunks = []
-
-    curr_line = 0
-    curr_chunk = []
-    for line in lines:
-        if curr_line % max_lines == 0 and curr_line > 0:
-            chunks.append(curr_chunk)
-            curr_chunk = []
-        curr_chunk.append(line)
-        curr_line += 1
-
-    if len(curr_chunk) > 0:
-        chunks.append(curr_chunk)
-
-    return chunks
->>>>>>> b98dacf3841f966582bb0bbe1a2862e70874c165
 
 class Gaminator(commands.Cog):
     def __init__(self, bot):
@@ -128,7 +72,6 @@ class Gaminator(commands.Cog):
 
     @commands.command(name='other-games')
     async def other_games(self, ctx):
-<<<<<<< HEAD
         formatted_roles_dict = format_roles_dict(ROLES['other_games'])
         pages = page_dict_as_lines(formatted_roles_dict)
 
@@ -147,33 +90,10 @@ class Gaminator(commands.Cog):
 
         roles_to_add = []
         roles_to_remove = []
-=======
-        og_dict = ROLES['other_games']
-        og_list = []
-
-        for k, v in og_dict.items():
-            og_list.append('`@' + k + '` - ' + v[0].title())
-
-        chunked_lines = chunk_lines(og_list)
-
-        base_embed = default_embed(
-            title='Other Games'
-        )
-        add_embed = default_embed(
-            title='You Will Add'
-        )
-
-        result_msg = await ctx.send(embed=base_embed)
-        add_msg = await ctx.send(embed=add_embed)
-
-        page = 0
-        await set_page(page, chunked_lines, result_msg)
->>>>>>> b98dacf3841f966582bb0bbe1a2862e70874c165
 
         while True:
             payload = await self.bot.wait_for('reaction_add', timeout=60.0)
 
-<<<<<<< HEAD
             if payload[0].emoji == '\u2b05' and current_page_num > 0:
                 current_page_num -= 1
                 current_page_dict = get_current_page_dict(pages[current_page_num])
@@ -203,21 +123,6 @@ class Gaminator(commands.Cog):
                     roles_to_add_field = "\n".join(role_dict_list_to_role_ping_list(roles_to_add))
                     role_embed.set_field_at(0, name='Adding', value=('None' if len(roles_to_add) == 0 else roles_to_add_field))
                     await role_msg.edit(embed=role_embed)
-=======
-            if payload[1].id != ctx.message.author.id:
-                continue
-
-            if payload[0].emoji == '\u2b05': # left arrow
-                if page > 0:
-                    page -= 1
-                    await set_page(page, chunked_lines, result_msg)
-            elif payload[0].emoji == '\u27a1': # right arrow
-                if page < len(chunked_lines) - 1:
-                    page += 1
-                    await set_page(page, chunked_lines, result_msg)
-
-
->>>>>>> b98dacf3841f966582bb0bbe1a2862e70874c165
 
 def setup(bot):
     bot.add_cog(Gaminator(bot))

--- a/modules/config.py
+++ b/modules/config.py
@@ -89,7 +89,6 @@ def read_config():
 
     # Pick up Voluspa named Env Vars
     voluspa_config = ['VOLUSPA_PREFIX', 'VOLUSPA_FEEDBACK_CHANNEL_ID']
-    secrets['Voluspa'] = {}
     for ve in voluspa_config:
         if os.getenv(ve):
             secrets['Voluspa'][ve.split('_', maxsplit=1)[1].lower()] = getenv_cast(ve)

--- a/modules/config.py
+++ b/modules/config.py
@@ -88,6 +88,8 @@ def read_config():
         secrets = env_secrets
 
     # Pick up Voluspa named Env Vars
+    if 'Voluspa' not in secrets:
+        secrets['Voluspa'] = {}
     voluspa_config = ['VOLUSPA_PREFIX', 'VOLUSPA_FEEDBACK_CHANNEL_ID']
     for ve in voluspa_config:
         if os.getenv(ve):

--- a/modules/emoji_utils.py
+++ b/modules/emoji_utils.py
@@ -1,0 +1,23 @@
+def ri_alphabet(n):
+    if n < 1:
+        n = 1
+    elif n > 26:
+        n = 26
+
+    current_emoji = '\U0001f1e6' # Regional Indicator A
+    i = 0
+    while i < n:
+        yield current_emoji
+
+        current_emoji = chr(ord(current_emoji) + 1)
+        i += 1
+
+def ri_at_index(i):
+    if i < 0:
+        i = 0
+    elif i > 25:
+        i = 25
+
+    a = '\U0001f1e6'
+
+    return chr(ord(a) + i)

--- a/modules/external_services/bungie.py
+++ b/modules/external_services/bungie.py
@@ -9,7 +9,7 @@ logger = logging.getLogger('voluspa.bungie_requests')
 
 
 async def async_bungie_request_handler(target_endpoint, request_url=None, params=None, response_handler=None):
-    bungie_platform_url = 'https://www.bungie.net/platform'
+    bungie_platform_url = 'https://www.bungie.net/Platform'
     _request_url = request_url if request_url else bungie_platform_url
     resp = await async_request_handler(_request_url,
                                        target_endpoint,

--- a/modules/logger.py
+++ b/modules/logger.py
@@ -10,7 +10,7 @@ def log_to_channel(log_channel, log_msg):
     pass
 
 
-def _setup_logging(log_level=logging.DEBUG):
+def _setup_logging(log_level=logging.INFO):
     logging.getLogger().handlers.clear()
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)

--- a/voluspa.py
+++ b/voluspa.py
@@ -57,7 +57,8 @@ cog_extensions = [
     'cogs.cog_control',
     #'cogs.roster',
     'jishaku',
-    #'cogs.console' # https://github.com/Gorialis/jishaku/issues/55
+    #'cogs.console', # https://github.com/Gorialis/jishaku/issues/55
+    'cogs.gaminator',
 ]
 
 


### PR DESCRIPTION
Too bad reactions are s l o w to await, Could possibly swap out for a text based interface? But then that's pretty much just the system we already have.

EDIT 1: Actually, could clear just user reactions between pages and remove surplus bot reactions on the last page when needed. That could be a good option?

EDIT 2: Unfortunately the Discord API doesn't have an endpoint for inserting a reaction at an index or editing a reaction, so EDIT 1 isn't really an option.

EDIT 3: I also tried parallelising the reaction add with `asyncio.as_completed` but surprisingly, that didn't help with speed at all. Must be internal rate limiting to the Discord API?