### PR TITLE
Updates for discord.py 2.0.1

### DIFF
--- a/cogs/autorole.py
+++ b/cogs/autorole.py
@@ -930,5 +930,5 @@ class Autorole(commands.Cog):
     #     return member_list
 
 
-def setup(bot):
-    bot.add_cog(Autorole(bot))
+async def setup(bot):
+    await bot.add_cog(Autorole(bot))

--- a/cogs/cache.py
+++ b/cogs/cache.py
@@ -156,5 +156,5 @@ class Cache(commands.Cog):
         await ctx.send(embed=embed)
 
 
-def setup(bot):
-    bot.add_cog(Cache(bot))
+async def setup(bot):
+    await bot.add_cog(Cache(bot))

--- a/cogs/cog_control.py
+++ b/cogs/cog_control.py
@@ -50,5 +50,5 @@ class CogControl(commands.Cog):
             await ctx.send('**`SUCCESS`**')
 
 
-def setup(bot):
-    bot.add_cog(CogControl(bot))
+async def setup(bot):
+    await bot.add_cog(CogControl(bot))

--- a/cogs/console.py
+++ b/cogs/console.py
@@ -12,5 +12,5 @@ class Console(JishakuBase, metaclass=GroupCogMeta, command_parent=jk):
     pass
 
 
-def setup(bot: commands.Bot):
+async def setup(bot: commands.Bot):
     await bot.add_cog(Console(bot))

--- a/cogs/console.py
+++ b/cogs/console.py
@@ -13,4 +13,4 @@ class Console(JishakuBase, metaclass=GroupCogMeta, command_parent=jk):
 
 
 def setup(bot: commands.Bot):
-    bot.add_cog(Console(bot))
+    await bot.add_cog(Console(bot))

--- a/cogs/destinyart.py
+++ b/cogs/destinyart.py
@@ -114,5 +114,5 @@ class DestinyArt(commands.Cog):
         await ctx.send(embed=self.create_destiny_art_embed(*self.emotes_info))
 
 
-def setup(bot):
-    bot.add_cog(DestinyArt(bot))
+async def setup(bot):
+    await bot.add_cog(DestinyArt(bot))

--- a/cogs/feedback.py
+++ b/cogs/feedback.py
@@ -35,5 +35,5 @@ class Feedback(commands.Cog):
         logger.info('Feedback has been sent.')
 
 
-def setup(bot):
-    bot.add_cog(Feedback(bot))
+async def setup(bot):
+    await bot.add_cog(Feedback(bot))

--- a/cogs/funstuff.py
+++ b/cogs/funstuff.py
@@ -82,5 +82,5 @@ class FunStuff(commands.Cog):
     #     await ctx.send(req.text)
 
 
-def setup(bot):
-    bot.add_cog(FunStuff(bot))
+async def setup(bot):
+    await bot.add_cog(FunStuff(bot))

--- a/cogs/gaminator.py
+++ b/cogs/gaminator.py
@@ -151,5 +151,5 @@ class Gaminator(commands.Cog):
             self.bot.get_command('game-roles').reset_cooldown(ctx)
 
 
-def setup(bot):
-    bot.add_cog(Gaminator(bot))
+async def setup(bot):
+    await bot.add_cog(Gaminator(bot))

--- a/cogs/kudos.py
+++ b/cogs/kudos.py
@@ -32,6 +32,6 @@ class Kudos(commands.Cog):
         await ctx.send('send_kudos')
 
 
-def setup(bot):
-    bot.add_cog(Kudos(bot))
+async def setup(bot):
+    await bot.add_cog(Kudos(bot))
 

--- a/cogs/members.py
+++ b/cogs/members.py
@@ -455,5 +455,5 @@ class Members(commands.Cog):
         await ctx.send(embed=embed)
 
 
-def setup(bot):
-    bot.add_cog(Members(bot))
+async def setup(bot):
+    await bot.add_cog(Members(bot))

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -135,7 +135,7 @@ class Polls(commands.Cog):
                 poll_embed=gen_poll_embed(poll_args)
                 result_msg = await ctx.send(embed=poll_embed)
                 poll_embed.add_field(name="Poll Reference", value=result_msg.id)
-                await result_msg.edit(embed=poll_embed)
+                result_msg = await result_msg.edit(embed=poll_embed)
 
             react_char = '\U0001f1e6'
             for arg_iter in range(1, len(poll_args)):
@@ -264,5 +264,5 @@ class Polls(commands.Cog):
                 png_wrapper.close()
                 plt.close()
 
-def setup(bot):
-    bot.add_cog(Polls(bot))
+async def setup(bot):
+    await bot.add_cog(Polls(bot))

--- a/cogs/systems.py
+++ b/cogs/systems.py
@@ -110,5 +110,5 @@ class Systems(commands.Cog):
         await ctx.send(embed=confirm_embed)
 
 
-def setup(bot):
-    bot.add_cog(Systems(bot))
+async def setup(bot):
+    await bot.add_cog(Systems(bot))

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -130,5 +130,5 @@ class Utilities(commands.Cog):
         await ctx.send(embed=datetime_embed)
 
 
-def setup(bot):
-    bot.add_cog(Utilities(bot))
+async def setup(bot):
+    await bot.add_cog(Utilities(bot))

--- a/modules/paging.py
+++ b/modules/paging.py
@@ -69,7 +69,7 @@ class _MenuBase:
         menu_field = self._get_menu_field()
         self._menu_embed.set_field_at(self._menu_field_index, name=f'Page {self._current_page_index + 1}/{len(self._pages)}', value=menu_field, inline=False)
 
-        await self._menu_msg.edit(embed=self._menu_embed)
+        self._menu_msg = await self._menu_msg.edit(embed=self._menu_embed)
         await self._set_reactions()
 
 
@@ -230,7 +230,7 @@ class MenuWithOptions(_MenuBase):
                 self._selected_options.remove(self._pages[self._current_page_index][index_of_ri(reaction.emoji)])
 
             self.update_feedback_ui()
-            await self._menu_msg.edit(embed=self._menu_embed)
+            self._menu_msg = await self._menu_msg.edit(embed=self._menu_embed)
 
             return False
 
@@ -321,7 +321,7 @@ class MenuWithCustomOptions(MenuWithOptions):
                 self._selected_options.remove(self._pages[self._current_page_index][reaction.emoji])
 
             self.update_feedback_ui()
-            await self._menu_msg.edit(embed=self._menu_embed)
+            self._menu_msg = await self._menu_msg.edit(embed=self._menu_embed)
 
             return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 PyYAML==5.4
 
 # ASYNC
-uvloop==0.14.0
+uvloop==0.17.0
 
 # HTTP
 requests==2.22.0
@@ -12,7 +12,7 @@ aiohttp>=3.7.4
 fuzzywuzzy[speedup]==0.17.0
 
 # API's
-discord.py[voice]==1.7.3
+discord.py[voice]==2.0.1
 
 # CHARTS
 matplotlib>=3.1.1
@@ -23,7 +23,7 @@ emoji==0.5.4
 titlecase==0.12.0
 
 # Discord.py DEBUG
-jishaku==1.17.1.181
+jishaku==2.5.1
 
 # TESTING
 # tox==3.13.2

--- a/voluspa.py
+++ b/voluspa.py
@@ -40,6 +40,7 @@ caches.set_config(CONFIG.Voluspa.cache)
 intents = discord.Intents.default()
 intents.members = True
 intents.presences = True
+intents.message_content = True
 
 # Setup Initial Stuff
 client = discord.Client(intents=intents)
@@ -231,14 +232,15 @@ async def on_command_error(ctx, error):
 #     traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
 
 
-def main():
+async def main():
     logger.info('// Völuspá / Booting...')
 
     logger.info('Starting bot...')
-    for extension in cog_extensions:
-        bot.load_extension(extension)
-    bot.run(CONFIG.Discord.api_key)
+    async with bot:
+        for extension in cog_extensions:
+            await bot.load_extension(extension)
+        await bot.start(CONFIG.Discord.api_key)
 
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
Had a look through the migration guide - looks like most things were already okay with the following two exceptions:

https://discordpy.readthedocs.io/en/latest/migrating.html#removing-in-place-edits
https://discordpy.readthedocs.io/en/latest/migrating.html#extension-and-cog-loading-unloading-is-now-asynchronous

Also needed to add message_content intents as we knew.

Also needed to bump Jishaku and UVLoop as the older versions were throwing stack traces. No robust testing here but with the bumped version, Voluspa started and worked with a few select commands.