### PR TITLE
Install reqs for Pylint

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install pylint
     - name: Analysing the code with pylint
       run: |


### PR DESCRIPTION
Installs dependencies via requirements.txt to ensure Pylint can successfully do its thing.